### PR TITLE
免翻页脚本

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,2 +1,3 @@
 <!-- start custom footer snippets -->
+<script src="https://greasyfork.org/scripts/26309/code/streamline.js"></script>
 <!-- end custom footer snippets -->


### PR DESCRIPTION
写了个脚本，可以点开连接后查询后续步骤，把它加载出来然后插入到当前教程的下面，不用点下一步的连接。

大概这么个效果：

![2](https://cloud.githubusercontent.com/assets/5713045/21680512/1a43064e-d342-11e6-9755-f9e6423a1552.png)

然后会在菜单插入对应当前页面的英文版连接：

![image](https://cloud.githubusercontent.com/assets/5713045/21680527/30cca398-d342-11e6-92bf-04b9b8b776a5.png)